### PR TITLE
Retangles' close button position fixed

### DIFF
--- a/src/feedbackplus.css
+++ b/src/feedbackplus.css
@@ -37,7 +37,7 @@
 
 .feedbackplus.feedbackplus-highlight {
   position: absolute;
-  border: 5px solid #fcc934;
+  border: 2px solid #fcc934;
 }
 
 .feedbackplus.feedbackplus-highlight:hover {
@@ -57,12 +57,12 @@
   display: none;
   margin-right: 10px;
   position: absolute;
-  background-color: white;
+  background-color: #ff0000;
   border-radius: 50%;
-  border: 2px solid black;
+  border: 2px solid #ff222295;
   padding: 5px;
-  top: -20px;
-  right: -30px;
+  top: -10px;
+  right: -22px;
   cursor: pointer;
   height: 15px;
   width: 15px;


### PR DESCRIPTION
This commit introduces changes to the code related to the styling and functionality of the feedback plus feature. The original code had an issue with the close button's visibility and accessibility, which has been addressed in this modification.

Here are the specific changes made:

1. Modified the feedbackplus.feedbackplus-highlight class:

- Changed the border width from 5px to 2px.
- Set the background color to rgba(255, 221, 0, 0.353).

2. Modified the feedbackplus.feedbackplus-tool-close class:

- Altered the display property to none.
- Adjusted the margin-right value to 10px.
- Updated the background color to #ff0000 (red) for better visibility.
- Set the border color to #ff222295.
- Adjusted the padding, top, and right properties for proper positioning.
- Defined a fixed height and width of 15px.

These changes were necessary to resolve the issue where the close button was not clickable due to its previous position being too far away from the associated rectangles. With these modifications, the close button is now properly located in the top right corner of the rectangles and can be easily accessed and clicked.

## Old:
<img src="https://i.ibb.co/VtmRLbZ/old.png" />

## With my modifications:
<img src="https://i.ibb.co/TgrjzN9/new.png" />

(Sizes of the retangles does not matter, the close button is correctly placed now)